### PR TITLE
Round after merging entries

### DIFF
--- a/hamster-export
+++ b/hamster-export
@@ -484,9 +484,10 @@ if __name__ == "__main__":
     timesheet = Timesheet.from_hamster_facts(storage, from_, till)
     timesheet.check_activities(activities)
 
-    timesheet.round_up(parse_round(args.round))
     if args.short:
         timesheet.shorten()
+
+    timesheet.round_up(parse_round(args.round))
 
     profile.process(timesheet)
 


### PR DESCRIPTION
If using the short option, I think it makes more sense to first merge and then round. Especially if you switch very often and have only small chunks of time, but several times a day for the same activity and a bigger rounding interval -- say 15 minutes or so -- this sums up to a huge difference in total really fast otherwise. 
