### PR TITLE
Merge descriptions

### DIFF
--- a/hamster-export
+++ b/hamster-export
@@ -101,9 +101,11 @@ class Timesheet(object):
             if len(items) > 1:
                 item.duration = sum(map(operator.attrgetter('duration'),
                                         items))
+                item.description = ''.join(filter(lambda i: i or '', map(
+                    operator.attrgetter('description'), items)))
             return item
 
-        key = operator.attrgetter('date', 'name', 'description')
+        key = operator.attrgetter('date', 'name')
         merged = []
         for key, items in itertools.groupby(sorted(self.entries, key=key),
                                             key=key):

--- a/hamster-export
+++ b/hamster-export
@@ -101,7 +101,7 @@ class Timesheet(object):
             if len(items) > 1:
                 item.duration = sum(map(operator.attrgetter('duration'),
                                         items))
-                item.description = ''.join(filter(lambda i: i or '', map(
+                item.description = ', '.join(filter(lambda i: i or '', map(
                     operator.attrgetter('description'), items)))
             return item
 


### PR DESCRIPTION
Merge entries of the same activity even if description differs. Do not use description in key for grouping entries. 
Merge the description of single items into comma separated list of items. 