### PR TITLE
Do not edit in CVS profile by default unless editor is explicitly sta…

### DIFF
--- a/hamster-export
+++ b/hamster-export
@@ -336,7 +336,11 @@ class CSV(Profile):
 
     def process(self, timesheet, **kwargs):
         timesheet = self.filter_timesheet(timesheet)
-        timesheet = ActiveCollab.edit_timesheet(timesheet)
+
+        editor = self._options.get('editor')
+        if editor:
+            timesheet = Profile.edit_timesheet(timesheet, editor)
+            
         timesheet.check_activities(self._activities.values())
 
         output = StringIO.StringIO()


### PR DESCRIPTION
…ted in profile.

I think for CVS export it is not that usefull to present an editor every time, because usually when doing exports to files you will look at these files somehow afterwards anyway. 
This is different from exporting to a remote system like ActiveCollab. 

This PR changes default behaviour for CSV profile. Editing the data before export is only done if explicitly requested in the profile by stating an editor command. 